### PR TITLE
zfsuserrefs.sh should skip missing dataset+snapshot

### DIFF
--- a/backend/zfsuserrefs.sh
+++ b/backend/zfsuserrefs.sh
@@ -55,7 +55,7 @@ countZFSUserRefs()
       continue
     fi
 
-    item_count=$(zfs list -Hp -d 1 -t snapshot -o userrefs ${ZNAME}@${2})
+    item_count=$(zfs list -Hp -d 1 -t snapshot -o userrefs ${ZNAME}@${2} 2>/dev/null || echo 0)
     if [ $? -eq 0 -a "x$item_count" != "x" ]; then
       CNT=$(($CNT + $item_count))
     fi


### PR DESCRIPTION
When traversing ZFS pool descendants, skip over any dataset that does not contain a matching snapshot; by returning zero userrefs.

I observed that having a Poudriere jail running, the traversal over these causes `lpreserver` to error because these contained no matching snapshot. This change fixes this problem by returning a value of zero over these kinds of transient ZFS datasets (where no snapshot were taken.)