### PR TITLE
Chown logdir to root

### DIFF
--- a/backend/functions.sh
+++ b/backend/functions.sh
@@ -38,6 +38,8 @@ export DBDIR LOGDIR PROGDIR CMDLOG REPCONF REPLOGSEND REPLOGRECV MSGQUEUE SSHPRO
 # Create the logdir
 if [ ! -d "$LOGDIR" ] ; then
    mkdir -p ${LOGDIR}
+   chown -R root:root ${LOGDIR}
+   chmod 600 ${LOGDIR}
 fi
 
 uname -r | grep -q 10.0

--- a/backend/functions.sh
+++ b/backend/functions.sh
@@ -38,8 +38,8 @@ export DBDIR LOGDIR PROGDIR CMDLOG REPCONF REPLOGSEND REPLOGRECV MSGQUEUE SSHPRO
 # Create the logdir
 if [ ! -d "$LOGDIR" ] ; then
    mkdir -p ${LOGDIR}
-   chown -R root:root ${LOGDIR}
-   chmod 600 ${LOGDIR}
+   chown -R root ${LOGDIR}
+   chmod 700 ${LOGDIR}
 fi
 
 uname -r | grep -q 10.0


### PR DESCRIPTION
This chowns ```${LOGDIR}``` to ```root``` and sets permission on the folder to ```700``` so no other users or groups are able to read or modify the logfiles.