### PR TITLE
iscsisave openssl

### DIFF
--- a/backend/functions.sh
+++ b/backend/functions.sh
@@ -1986,10 +1986,9 @@ export_iscsi_zpool() {
 }
 
 save_iscsi_zpool_data() {
-
   OPENSSL="$1"
   LDATA="$2"
-  if [ -z "$2" -o -z "$3" ] ; then
+  if [ -z "$3" -o -z "$4" ] ; then
      exit_err "Usage: lpreserver replicate saveiscsi <zpool> <target host> [password file]"
   fi
   PASSFILE="$4"
@@ -2183,13 +2182,13 @@ save_iscsi_zpool_data() {
 
   if [ "$OPENSSL" = "openssl" ]; then
     tempfoo=`basename $0`
-    TMPFILE=`mktemp -q /tmp/${tempfoo}.XXXXXX`
+    TEMPFILE=`mktemp -q /tmp/${tempfoo}.XXXXXX`
 
     if [ $? -ne 0 ]; then
       exit_err "Failed creating temp file"
     fi
 
-    TMPTAR=`mktemp -q /tmp/${tempfoo}.XXXXXX.tar`
+    TMPTAR=`mktemp -q /tmp/${tempfoo}.XXXXXX`
     if [ $? -ne 0 ]; then
       exit_err "Failed creating temp file"
     fi
@@ -2199,14 +2198,14 @@ save_iscsi_zpool_data() {
     mkdir -p /var/db/lpreserver/backupkeys
     file="/var/db/lpreserver/backupkeys/${SANELDATA}-${REPHOST}.ssl"
 
-    openssl smime -encrypt -aes256 -in $TMPTAR -out $file ${PASSFILE}
-    rm -f $TMPTAR $TMPFILE
+    openssl smime -encrypt -aes256 -in $TMPTAR -binary -out $file ${PASSFILE}
+
+    rm -f $TMPTAR $TEMPFILE
 
     if [ $? -ne 0 ]; then
       exit_err "Failed encrypting tar"
     fi
 
-    rm $TMPFILE
     echo "SMIME encrypted iSCSI config and GELI key saved to: $file"
     echo ""
     echo "!! -- PLEASE KEEP THIS IN A SAFE LOCATION -- !!"

--- a/backend/functions.sh
+++ b/backend/functions.sh
@@ -1986,13 +1986,15 @@ export_iscsi_zpool() {
 }
 
 save_iscsi_zpool_data() {
-  LDATA="$1"
-  if [ -z "$1" -o -z "$2" ] ; then
+
+  OPENSSL="$1"
+  LDATA="$2"
+  if [ -z "$2" -o -z "$3" ] ; then
      exit_err "Usage: lpreserver replicate saveiscsi <zpool> <target host> [password file]"
   fi
-  PASSFILE="$3"
+  PASSFILE="$4"
 
-  repLine=`cat ${REPCONF} | grep "^${LDATA}:.*:${2}:"`
+  repLine=`cat ${REPCONF} | grep "^${LDATA}:.*:${3}:"`
   if [ -z "$repLine" ] ; then
      exit_err "No such replication task: ${LDATA}"
   fi
@@ -2020,7 +2022,7 @@ save_iscsi_zpool_data() {
 
   truncate -s 5M ${LPFILE}
   MD=`mdconfig -t vnode -f ${LPFILE}`
-  if [ "$OPENSSL" = "openssl" ]
+  if [ "$OPENSSL" = "openssl" ]; then
     # Generate and store random password as per Nick
     echo "Generating random password..."
     PASSWORD=`openssl rand -base64 64`
@@ -2209,7 +2211,7 @@ save_iscsi_zpool_data() {
     echo ""
     echo "!! -- PLEASE KEEP THIS IN A SAFE LOCATION -- !!"
     echo ""
-    echo "If you lose the private key for this keypair you will be
+    echo "If you lose the private key for this keypair you will be"
     echo "unable to restore your data!"
   else
 

--- a/backend/functions.sh
+++ b/backend/functions.sh
@@ -2194,7 +2194,7 @@ save_iscsi_zpool_data() {
     fi
 
     echo "$PASSWORD" > $TEMPFILE
-    tar cf $TMPTAR $TMPFILE $LPFILE
+    tar cf $TMPTAR $TEMPFILE $LPFILE
     mkdir -p /var/db/lpreserver/backupkeys
     file="/var/db/lpreserver/backupkeys/${SANELDATA}-${REPHOST}.ssl"
 

--- a/backend/functions.sh
+++ b/backend/functions.sh
@@ -1991,7 +1991,24 @@ save_iscsi_zpool_data() {
 
   truncate -s 5M ${LPFILE}
   MD=`mdconfig -t vnode -f ${LPFILE}`
-  if [ -n "$PASSFILE" ] ; then
+  if [ "$OPENSSL" = "openssl" ]
+    # Generate and store random password as per Nick
+    echo "Generating random password..."
+    PASSWORD=`openssl rand -base64 64`
+    echo "Creating GELI provider..."
+    echo "$PASSWORD" | geli init -J - ${MD} >/dev/null 2>/dev/null
+    if [ $? -ne 0 ] ; then
+       mdconfig -d -u $MD
+       rm ${LPFILE}
+       exit_err "Failed GELI init"
+    fi
+    echo "$PASSWORD" | geli attach -j - ${MD} >/dev/null 2>/dev/null
+    if [ $? -ne 0 ] ; then
+       mdconfig -d -u $MD
+       rm ${LPFILE}
+       exit_err "Failed GELI attach"
+    fi
+  elif [ -n "$PASSFILE" ] ; then
     echo "Creating GELI provider..."
     cat ${PASSFILE} | geli init -J - ${MD} >/dev/null 2>/dev/null
     if [ $? -ne 0 ] ; then
@@ -2133,12 +2150,47 @@ save_iscsi_zpool_data() {
   geli stop /dev/${MD}.eli
   mdconfig -d -u ${MD}
 
-  echo "iSCSI config and GELI key saved to: $LPFILE"
-  echo ""
-  echo "!! -- PLEASE KEEP THIS IN A SAFE LOCATION -- !!"
-  echo ""
-  echo "If you lose the password of this file you will be unable"
-  echo "to restore your data!"
+  if [ "$OPENSSL" = "openssl" ]; then
+    tempfoo=`basename $0`
+    TMPFILE=`mktemp -q /tmp/${tempfoo}.XXXXXX`
+
+    if [ $? -ne 0 ]; then
+      exit_err "Failed creating temp file"
+    fi
+
+    TMPTAR=`mktemp -q /tmp/${tempfoo}.XXXXXX.tar`
+    if [ $? -ne 0 ]; then
+      exit_err "Failed creating temp file"
+    fi
+
+    echo "$PASSWORD" > $TEMPFILE
+    tar cf $TMPTAR $TMPFILE $LPFILE
+    mkdir -p /var/db/lpreserver/backupkeys
+    file="/var/db/lpreserver/backupkeys/${SANELDATA}-${REPHOST}.ssl"
+
+    openssl smime -encrypt -aes256 -in $TMPTAR -out $file ${PASSFILE}
+    rm -f $TMPTAR $TMPFILE
+
+    if [ $? -ne 0 ]; then
+      exit_err "Failed encrypting tar"
+    fi
+
+    rm $TMPFILE
+    echo "SMIME encrypted iSCSI config and GELI key saved to: $file"
+    echo ""
+    echo "!! -- PLEASE KEEP THIS IN A SAFE LOCATION -- !!"
+    echo ""
+    echo "If you lose the private key for this keypair you will be
+    echo "unable to restore your data!"
+  else
+
+    echo "iSCSI config and GELI key saved to: $LPFILE"
+    echo ""
+    echo "!! -- PLEASE KEEP THIS IN A SAFE LOCATION -- !!"
+    echo ""
+    echo "If you lose the password of this file you will be unable"
+    echo "to restore your data!"
+  fi
 
   exit 0
 }

--- a/backend/functions.sh
+++ b/backend/functions.sh
@@ -2202,7 +2202,7 @@ save_iscsi_zpool_data() {
 
   if [ "$OPENSSL" = "openssl" ]; then
     tempfoo=`basename $0`
-    TMPFILE=`mktemp -q /tmp/${tempfoo}.XXXXXX`
+    TEMPFILE=`mktemp -q /tmp/${tempfoo}.XXXXXX`
 
     if [ $? -ne 0 ]; then
       exit_err "Failed creating temp file"
@@ -2213,14 +2213,14 @@ save_iscsi_zpool_data() {
       exit_err "Failed creating temp file"
     fi
 
-    echo "$PASSWORD" > $TMPFILE
-    tar cf $TMPTAR $TMPFILE $LPFILE
+    echo "$PASSWORD" > $TEMPFILE
+    tar cf $TMPTAR $TEMPFILE $LPFILE
     mkdir -p /var/db/lpreserver/backupkeys
     file="/var/db/lpreserver/backupkeys/${SANELDATA}-${REPHOST}.ssl"
 
     openssl smime -encrypt -aes256 -in $TMPTAR -binary -out $file ${PASSFILE}
 
-    rm -f $TMPTAR $TMPFILE
+    rm -f $TMPTAR $TEMPFILE
 
     if [ $? -ne 0 ]; then
       exit_err "Failed encrypting tar"

--- a/lpreserver
+++ b/lpreserver
@@ -777,7 +777,16 @@ case "$1" in
 	  	      ${PROGDIR}/backend/runrep.sh "$2" "$3"
 		      exit $?
 		      ;;
-           saveiscsi) require_root ; save_iscsi_zpool_data "$2" "$3" "$4" "$5" ;;
+           saveiscsi)
+                      if [ "$2" = "openssl" ] ; then
+                  	require_root ; save_iscsi_zpool_data "openssl" "$3" "$4" "$5"
+                      elif [ "$2" = "geli" ] ; then
+                        require_root ; save_iscsi_zpool_data "geli" "$3" "$4" "$5"
+                      else
+                        require_root ; save_iscsi_zpool_data "geli" "$2" "$3" "$4"
+                      fi
+                      ;;
+
              exclude) require_root ;
 		      DATASET="${2}"
                       if ! isZFSvalid "$DATASET"; then

--- a/lpreserver
+++ b/lpreserver
@@ -175,6 +175,7 @@ run options:
 saveiscsi options:
 
 	saveiscsi <localdataset/zpool> <target host> [password file]
+	saveiscsi geli <localdataset/zpool> <target host> [password file]
 
 	Creates a GELI encrypted file, which contains all the iSCSI connection
 	information and GELI key for the replication target. Will prompt for
@@ -182,6 +183,12 @@ saveiscsi options:
 
 	This file can then be used with the "replicate add" command to import
 	the backup zpool on another system or from the PC-BSD install media.
+
+    saveiscsi openssl <localdataset/zpool> <target host> <key>
+
+    Generates a random password for the GELI encrypted file described above and
+    then saves the password file and the GELI encrypted file in a tar which is
+    encrypted to an SMIME public key using OpenSSL
 
 exclude options:
 
@@ -769,7 +776,7 @@ case "$1" in
 	  	      ${PROGDIR}/backend/runrep.sh "$2" "$3"
 		      exit $?
 		      ;;
-		saveiscsi) require_root ; save_iscsi_zpool_data "$2" "$3" "$4" ;;
+           saveiscsi) require_root ; save_iscsi_zpool_data "$2" "$3" "$4" "$5" ;;
              exclude) require_root ;
 		      DATASET="${2}"
                       if ! isZFSvalid "$DATASET"; then


### PR DESCRIPTION
Adds the option ```iscsisave openssl <localdataset/zpool> <target host> <key>``` to lpreserver which encrypts the iSCSI data with a SMIME key. This allows automated encrypted backups without requiring the decryption key to be stored on the client host. It also allows the backup information to be automatically emailed to an administrator without also requiring the key to be transmitted. 

## Implementation - OpenSSL on GELI Volume

Preforms the normal backup procedure with a randomly generated GELI passphrase, creates a tar containing the GELI volume and random passphrase, and then encrypts the tar with OpenSSL using the specified SMIME public key. Once the file is decrypted the backup file is compatible with all existing restore scripts. 

## Usage
    saveiscsi options:
    
         saveiscsi <localdataset/zpool> <target host> [password file]
         saveiscsi geli <localdataset/zpool> <target host> [password file]
    
         Creates a GELI encrypted file, which contains all the iSCSI connection
         information and GELI key for the replication target. Will prompt for
         the password to set on this GELI encrypted file.
    
         This file can then be used with the "replicate add" command to import
         the backup zpool on another system or from the PC-BSD install media.
    
       saveiscsi openssl <localdataset/zpool> <target host> <key>
    
         Creates an SMIME encrypted file using OpenSSL, which contains all the iSCSI
         connection information and GELI key for the replication target.
         
         The information in this file can then be used to import the backup zpool
         on another system or from install media that includes stunnel.
