### PR TITLE
Issue #195, #200: fix sort_dset_by_clone's sorting

### DIFF
--- a/backend/functions.sh
+++ b/backend/functions.sh
@@ -1215,44 +1215,9 @@ build_dset_list()
 }
 
 sort_dset_by_clone() {
-  local PSETS=""
-  local CSETS=""
-  for dset in $DSETS
-  do
-     origin=`zfs list -H -o origin $dset`
-     # If no ORIGIN, we can add it back to the list
-     if [ -z "$origin" -o "$origin" = "-" ] ; then
-        PSETS=" $PSETS $dset "
-        continue
-     fi
-     CSETS=" $CSETS $dset "
-  done
-
-  DSETS="$PSETS"
-  if [ -n "$CSETS" ] ; then
-     add_dset_clone "$CSETS"
-  fi
-}
-
-add_dset_clone() {
-
-  local CSETS=""
-  unset PASSDSETS
-  local PASSDSETS=""
-
-  for dset in ${1}
-  do
-     origin=`zfs list -H -o origin $dset`
-     originraw="`echo $origin | cut -d '@' -f 1`"
-     case "${DSETS}" in
-        *" $originraw "*) DSETS=" $DSETS $dset " ;;
-        *) PASSDSETS=" $PASSDSETS $dset ";;
-     esac
-  done
-  # Be recursive until we add them all
-  if [ -n "$PASSDSETS" ] ; then
-     add_dset_clone "$PASSDSETS"
-  fi
+  # Sort datasets by creation time.  This ensures that parents will come before
+  # children, even for clones.  However, it will fail for promoted clones.
+  DSETS=`zfs list -Hp -o name,creation $DSETS | sort -n -k 2 | cut -w -f 1`
 }
 
 prune_remote_datasets() {


### PR DESCRIPTION
sort_dset_by_clone correctly sorts clones after their origins, but fails
to sort ordinary child datasets ("foo/bar") after their parents ("foo")
(Issue #200).  It also recurses infinitely when a dataset's origin is
excluded (Issue #195).

This commit fixes both issues by sorting the datasets by creation time.
However, it will now missort a promoted clone before its origin.  That
is a lesser bug, because AFAIK the only reason to promote a clone is to
destroy its parent.