### PR TITLE
TrueOS Core Issue #193: Update lpreserver.8

### DIFF
--- a/lpreserver.8
+++ b/lpreserver.8
@@ -153,4 +153,4 @@ lpreserver replicate add freenas.8343 backupuser 22 tank1 tankbackup/backups 22
    notated in 24hour time
 
 .Sh SEE ALSO
-http://wiki.pcbsd.org/index.php/Life_Preserver/
+https://github.com/trueos/lpreserver


### PR DESCRIPTION
- Fix dead link under .Sh SEE ALSO, now points to github repo for lpreserver.