### PR TITLE
Fix an undefined variable reference

### DIFF
--- a/backend/functions.sh
+++ b/backend/functions.sh
@@ -1278,6 +1278,7 @@ prune_old_remote_snaps() {
 start_rep_task() {
   LDATA="$1"
   hName=`hostname`
+  zStatus=1
 
   #save_mount_props "${DATASET}"
 


### PR DESCRIPTION
Without this change, line 1532 becomes a syntax error if, for any
reason, no datasets were replicated.