### PR TITLE
Make auto snapshot removal disk percentage adjustable

### DIFF
--- a/backend/functions.sh
+++ b/backend/functions.sh
@@ -82,6 +82,12 @@ setOpts() {
     export DUWARN=70
   fi
 
+  if [ -e "${DBDIR}/duprune" ] ; then
+    export DUPRUNE="`cat ${DBDIR}/duprune`"
+  else
+    export DUPRUNE=75
+  fi
+
   case $EMAILMODE in
       ALL|WARN|ERROR) ;;
 	*) export EMAILMODE="WARN";;

--- a/backend/functions.sh
+++ b/backend/functions.sh
@@ -1882,6 +1882,12 @@ do_pool_cleanup()
      return
   fi
 
+  # Is this zpool replicated
+  if [ -e "$REPCONF" ] ; then
+     repLine=`cat ${REPCONF} | grep "^${1}:"`
+     repHost=`echo $repLine | cut -d ':' -f 3`
+  fi
+
   # Before we start pruning, check if any replication is running
   local pidFile="${DBDIR}/.reptask-`echo ${1} | sed 's|/|-|g'`"
   if [ -e "${pidFile}" ] ; then
@@ -1901,17 +1907,21 @@ do_pool_cleanup()
         continue
      fi
 
-     echo_log "Pruning old snapshot: $snap"
-     rmZFSSnap "${1}" "$snap"
-     if [ $? -ne 0 ] ; then
-       haveMsg=1
-       echo_log "ERROR: (Low Disk Space) Failed pruning snapshot $snap on ${1}"
-       queue_msg "ERROR: (Low Disk Space) Failed pruning snapshot $snap on ${1} @ `date` \n\r`cat $CMDLOG`"
-     else
-       queue_msg "(Low Disk Space) Auto-pruned snapshot: $snap on ${1} @ `date`\n\r`cat $CMDLOG`"
-       haveMsg=1
-     fi
+     # Don't remove snapshots that hasn't been replicated yet
+     repSnap=`zfs get -d 1 lpreserver:${repHost} ${1} | grep LATEST | awk '{$1=$1}1' OFS=" " | tail -1 | cut -d '@' -f 2 | cut -d ' ' -f 1`
 
+     if [ ! "$repSnap" = "$snap" ] ; then
+        echo_log "Pruning old snapshot: $snap"
+        rmZFSSnap "${1}" "$snap"
+        if [ $? -ne 0 ] ; then
+           haveMsg=1
+           echo_log "ERROR: (Low Disk Space) Failed pruning snapshot $snap on ${1}"
+           queue_msg "ERROR: (Low Disk Space) Failed pruning snapshot $snap on ${1} @ `date` \n\r`cat $CMDLOG`"
+        else
+           queue_msg "(Low Disk Space) Auto-pruned snapshot: $snap on ${1} @ `date`\n\r`cat $CMDLOG`"
+           haveMsg=1
+        fi
+     fi
      # We only prune a single snapshot at this time, so lets end
      break
   done

--- a/backend/zfsmon.sh
+++ b/backend/zfsmon.sh
@@ -49,8 +49,8 @@ do
      haveMsg=1
   fi
 
-  # See if we can do any auto-cleanup of this pool
-  if [ $poolCap -gt 75 ] ; then
+  # See if we need to do any auto-cleanup of this pool
+  if [ $poolCap -gt $DUPRUNE ] ; then
      do_pool_cleanup "$zpool"
   fi
 

--- a/lpreserver
+++ b/lpreserver
@@ -266,6 +266,9 @@ Config options
 
      duwarn - Set to a disk percentage [0-99] at which to warn of low disk space
 
+    duprune - Set to a disk percentage [0-99] at which to begin removing old
+              snapshots
+
       email - Set the e-mail address to receive notifications
 		This will require that the \"mail\" command is setup for
 		outgoing mail
@@ -618,11 +621,12 @@ case "$1" in
     get) require_root
 	 # Display our options
 	 title
-	 echo "      Recursive mode: $RECURMODE"
-	 echo "   Prune remote mode: $PRUNEREMOTEMODE"
-	 echo "E-mail notifications: $EMAILMODE"
-	 echo "    E-mail addresses: $EMAILADDY"
-	 echo "  Disk space warn at: ${DUWARN}%"
+	 echo "               Recursive mode: $RECURMODE"
+	 echo "            Prune remote mode: $PRUNEREMOTEMODE"
+	 echo "         E-mail notifications: $EMAILMODE"
+	 echo "             E-mail addresses: $EMAILADDY"
+	 echo "           Disk space warn at: ${DUWARN}%"
+	 echo "Disk space prune snapshots at: ${DUPRUNE}%"
 	 exit 0
          ;;
 
@@ -639,8 +643,11 @@ case "$1" in
             email) echo "Setting email notification to: $3"
 	           echo "$3" > ${DBDIR}/emails ;;
            duwarn) if [ ! $(is_num "$3") ] ; then exit_err "Invalid number, must be 0-99"; fi
-		   echo "Setting disk warning capacity to: ${3}%"
+		   echo "Setting disk space warning capacity to: ${3}%"
 	           echo "$3" > ${DBDIR}/duwarn ;;
+          duprune) if [ ! $(is_num "$3") ] ; then exit_err "Invalid number, must be 0-99"; fi
+		   echo "Setting disk space snapshot prune to: ${3}%"
+	           echo "$3" > ${DBDIR}/duprune ;;
         recursive) case $3 in
 		  OFF|Off|off)  echo "Recursive mode disabled"
 			        touch ${DBDIR}/recursive-off ;;


### PR DESCRIPTION
This commit adds the setting 'duprune' which determines
when to start auto prune snapshots determined by
how much disk space is used up.

Example:
lpreserver set duprune 80

Defaults to 75